### PR TITLE
Remove file-based logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,13 @@ Common optional variables are shown below (defaults in parentheses):
 - `LOG_DB_PATH` – SQLite database for indexed logs and media metadata with WAL and batched writes (`room-logs/messages.db`)
 - `LOG_LEVEL` – log verbosity: `trace`, `debug`, `info`, `warn`, or `error` (`info`)
 - `BACKFILL_CONCURRENCY` – simultaneous backfill requests (`5`)
-- `LOG_MAX_BYTES` – rotate log files when they exceed this size (`5000000`)
-- `LOG_RETENTION_DAYS` – delete rotated log files and prune old log/media entries (`30`)
+- `LOG_RETENTION_DAYS` – prune old log and media entries (`30`)
 - `KEY_BACKUP_RECOVERY_KEY` – restore room keys from server backup
 - `KEY_REQUEST_INTERVAL_MS` – initial retry delay for missing keys (`1000`)
 - `KEY_REQUEST_MAX_INTERVAL_MS` – max retry delay for missing keys (`300000`)
 - `MSC4190` / `MSC3202` – enable experimental key-forwarding/device-masquerading (`true`)
 - `SESSION_SECRET` – encrypt session cache on disk
-- `LOG_SECRET` – encrypt per-room log files
+- `LOG_SECRET` – encrypt log entries in the database
 - `MEDIA_SECRET` – encrypt downloaded media files
 - `ENABLE_SEND_MESSAGE` – set to `1` to expose the `send_message` tool
 - `TEST_ROOM_ID` – sync only a specific room (empty)
@@ -119,13 +118,12 @@ encryption.
 
 ### Interpreting log messages
 
-Log files are written per room with lines prefixed by ISO timestamps. Use
-`LOG_LEVEL` to adjust verbosity. Logs rotate when they exceed `LOG_MAX_BYTES`,
-and old rotated files and database entries are pruned after
-`LOG_RETENTION_DAYS` days:
+Log entries are stored per room in the SQLite database with lines prefixed by
+ISO timestamps. Use `LOG_LEVEL` to adjust verbosity. Old database entries and
+media metadata are pruned after `LOG_RETENTION_DAYS` days:
 
 ```bash
-LOG_MAX_BYTES=1000000 npx ts-node beeper-mcp-server.ts
+npx ts-node beeper-mcp-server.ts
 ```
 
 Encryption can be enabled or disabled per storage type by setting or omitting

--- a/beeper-mcp-server.ts
+++ b/beeper-mcp-server.ts
@@ -36,7 +36,6 @@ import { initMcpServer } from './src/mcp.js';
 // --- Constants ---
 const CACHE_DIR = process.env.MATRIX_CACHE_DIR ?? './mx-cache';
 const LOG_DIR = process.env.MESSAGE_LOG_DIR ?? './room-logs';
-const LOG_MAX_BYTES = Number(process.env.LOG_MAX_BYTES ?? '5000000');
 const LOG_SECRET = process.env.LOG_SECRET;
 const MEDIA_SECRET = process.env.MEDIA_SECRET;
 const LOG_LEVEL = process.env.LOG_LEVEL ?? 'info';
@@ -314,8 +313,6 @@ async function restoreRoomKeys(client: MatrixClient, logger: Pino.Logger) {
 
   setupEventLogging(client, logger, {
     logDir: LOG_DIR,
-    logMaxBytes: LOG_MAX_BYTES,
-    logSecret: LOG_SECRET,
     mediaSecret: MEDIA_SECRET,
     mediaDownloader,
     queueLog,

--- a/mcp-tools.js
+++ b/mcp-tools.js
@@ -84,6 +84,7 @@ export function buildMcpServer(
       until: z.string().datetime().optional(),
     }),
     authWrapper(async ({ room_id, limit, since, until }) => {
+      if (!logDb) throw new Error('Log database not available');
       let lines = [];
       try {
         lines = queryFn(logDb, room_id, limit, since, until, logSecret);

--- a/setup.js
+++ b/setup.js
@@ -163,12 +163,8 @@ async function configure() {
       'Media encryption secret (leave blank for none)',
       env.MEDIA_SECRET || '',
     );
-    env.LOG_MAX_BYTES = await ask(
-      'Max log size in bytes before rotation',
-      env.LOG_MAX_BYTES || '5000000',
-    );
     env.LOG_RETENTION_DAYS = await ask(
-      'Days to retain rotated logs and metadata',
+      'Days to retain logs and metadata',
       env.LOG_RETENTION_DAYS || '30',
     );
     const enableSend = await ask(

--- a/src/event-logger.ts
+++ b/src/event-logger.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import Pino from 'pino';
 import { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 import {
-  appendWithRotate,
   getRoomDir,
   safeFilename,
   pushWithLimit,
@@ -15,8 +14,6 @@ export function setupEventLogging(
   logger: Pino.Logger,
   opts: {
     logDir: string;
-    logMaxBytes: number;
-    logSecret?: string;
     mediaSecret?: string;
     mediaDownloader: ReturnType<typeof createMediaDownloader>;
     queueLog: (
@@ -33,8 +30,6 @@ export function setupEventLogging(
 ) {
   const {
     logDir,
-    logMaxBytes,
-    logSecret,
     mediaSecret,
     mediaDownloader,
     queueLog,
@@ -212,7 +207,6 @@ export function setupEventLogging(
     const content = ev.getClearContent?.() || ev.getContent();
     const ts = new Date(ev.getTs() || Date.now()).toISOString();
     const dir = getRoomDir(logDir, rid);
-    const logf = path.join(dir, `${safeFilename(rid)}.log`);
     let line: string;
     if (type === 'm.room.message') {
       if (content.url) {
@@ -244,7 +238,6 @@ export function setupEventLogging(
     } else {
       line = `[${ts}] <${ev.getSender()}> [${type}]`;
     }
-    await appendWithRotate(logf, line, logMaxBytes, logSecret);
     queueLog(rid, ts, line, id);
     if (testLimit > 0) {
       testCount++;

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -78,6 +78,19 @@ test('list_messages passes parameters to queryLogs', async () => {
   assert.deepEqual(res.content[0].json, ['a', 'b']);
 });
 
+test('list_messages fails without log database', async () => {
+  const client = { getRooms: () => [] };
+  const srv = buildMcpServer(client, null, false, undefined);
+  await assert.rejects(
+    () =>
+      srv._registeredTools.list_messages.callback(
+        { room_id: '!r' },
+        { _meta: { apiKey: API_KEY } },
+      ),
+    /Log database not available/,
+  );
+});
+
 test('send_message only registered when enabled', async () => {
   const client = {
     getRooms: () => [],

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -3,23 +3,12 @@ export function safeFilename(s?: string): string;
 export function getRoomDir(base: string, roomId: string): string;
 export const pipelineAsync: (...streams: any[]) => Promise<void>;
 export function envFlag(name: string, def?: boolean): boolean;
-export function tailFile(
-  file: string,
-  limit: number,
-  secret?: string,
-): Promise<string[]>;
 export function encryptFileStream(
   src: NodeJS.ReadableStream,
   dest: string,
   secret: string,
 ): Promise<void>;
 export function decryptFile(file: string, secret: string): Promise<Buffer>;
-export function appendWithRotate(
-  file: string,
-  line: string,
-  maxBytes: number,
-  secret?: string,
-): Promise<void>;
 export function openLogDb(file: string): any;
 export function createLogWriter(
   db: any,


### PR DESCRIPTION
## Summary
- drop appendWithRotate file logging from event handler
- require log database for list_messages
- remove file log utilities, tests, and env vars

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c931991208323aa53ddebb29c24c6