### PR TITLE
feat: queue file log writes

### DIFF
--- a/beeper-mcp-server.ts
+++ b/beeper-mcp-server.ts
@@ -312,7 +312,7 @@ async function restoreRoomKeys(client: MatrixClient, logger: Pino.Logger) {
     process.exit(0);
   };
 
-  setupEventLogging(client, logger, {
+  const { flush: flushFileLogs } = setupEventLogging(client, logger, {
     logDir: LOG_DIR,
     logMaxBytes: LOG_MAX_BYTES,
     logSecret: LOG_SECRET,
@@ -324,6 +324,7 @@ async function restoreRoomKeys(client: MatrixClient, logger: Pino.Logger) {
     uid: UID,
     shutdown,
   });
+  flusher.register(flushFileLogs);
 
   await startSync(client, sessionStore, syncKey, logger, {
     concurrency: CONC,

--- a/bench/append-bench.js
+++ b/bench/append-bench.js
@@ -1,0 +1,33 @@
+import fs from 'fs/promises';
+import { appendWithRotate, createFileAppender } from '../utils.js';
+
+const ITER = 5000;
+const FILE1 = '.bench-direct.log';
+const FILE2 = '.bench-queued.log';
+
+async function benchDirect() {
+  await fs.unlink(FILE1).catch(() => {});
+  const start = Date.now();
+  for (let i = 0; i < ITER; i++) {
+    await appendWithRotate(FILE1, `line ${i}`, 10_000_000);
+  }
+  return Date.now() - start;
+}
+
+async function benchQueued() {
+  await fs.unlink(FILE2).catch(() => {});
+  const writer = createFileAppender(FILE2, 10_000_000, undefined, 1000, ITER);
+  const start = Date.now();
+  for (let i = 0; i < ITER; i++) {
+    writer.queue(`line ${i}`);
+  }
+  await writer.flush();
+  return Date.now() - start;
+}
+
+(async () => {
+  const d = await benchDirect();
+  const q = await benchQueued();
+  console.log(`direct: ${d}ms`);
+  console.log(`queued: ${q}ms`);
+})();

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -10,6 +10,7 @@ import {
   FileSessionStore,
   tailFile,
   appendWithRotate,
+  createFileAppender,
   openLogDb,
   insertLog,
   insertLogs,
@@ -339,6 +340,18 @@ test('createLogWriter queues and flushes entries', () => {
   flush();
   const lines = queryLogs(db, 'room');
   assert.deepStrictEqual(lines, ['[a]', '[b]']);
+});
+
+test('createFileAppender queues and flushes lines', async () => {
+  cleanup();
+  ensureDir(tmpBase);
+  const file = path.join(tmpBase, 'app.log');
+  const { queue, flush } = createFileAppender(file, 1000);
+  queue('a');
+  queue('b');
+  await flush();
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+  assert.deepStrictEqual(lines, ['a', 'b']);
 });
 
 test('insertMedia stores metadata and queryMedia retrieves it', () => {

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -20,6 +20,16 @@ export function appendWithRotate(
   maxBytes: number,
   secret?: string,
 ): Promise<void>;
+export function createFileAppender(
+  file: string,
+  maxBytes: number,
+  secret?: string,
+  flushMs?: number,
+  maxEntries?: number,
+): {
+  queue: (line: string) => void;
+  flush: () => Promise<void>;
+};
 export function openLogDb(file: string): any;
 export function createLogWriter(
   db: any,

--- a/utils.js
+++ b/utils.js
@@ -108,9 +108,13 @@ export async function tailFile(file, limit, secret) {
 }
 
 export async function appendWithRotate(file, line, maxBytes, secret) {
+  const payload = secret ? encrypt(line, secret) + '\n' : line + '\n';
+  await appendPayloadWithRotate(file, payload, maxBytes);
+}
+
+async function appendPayloadWithRotate(file, payload, maxBytes) {
   try {
     ensureDir(path.dirname(file));
-    const payload = secret ? encrypt(line, secret) + '\n' : line + '\n';
     const size = await fs.promises
       .stat(file)
       .then((s) => s.size)
@@ -127,6 +131,37 @@ export async function appendWithRotate(file, line, maxBytes, secret) {
   } catch (err) {
     logger.warn(`Failed to append to log file ${file}`, err);
   }
+}
+
+export function createFileAppender(
+  file,
+  maxBytes,
+  secret,
+  flushMs = 1000,
+  maxEntries = 100,
+) {
+  const buffer = [];
+  let flushing = false;
+  const flush = async () => {
+    if (flushing || buffer.length === 0) return;
+    flushing = true;
+    try {
+      const lines = buffer.splice(0, buffer.length);
+      const payload =
+        lines.map((l) => (secret ? encrypt(l, secret) : l)).join('\n') + '\n';
+      await appendPayloadWithRotate(file, payload, maxBytes);
+    } finally {
+      flushing = false;
+    }
+  };
+  setInterval(flush, flushMs).unref();
+  return {
+    queue(line) {
+      buffer.push(line);
+      if (buffer.length >= maxEntries) flush();
+    },
+    flush,
+  };
 }
 
 export function openLogDb(file) {


### PR DESCRIPTION
## Summary
- batch appendWithRotate writes via new `createFileAppender` and centralized flush helper
- queue event logger file writes and register flusher on shutdown
- add benchmark for append throughput

## Testing
- `npm test`
- `npm run lint`
- `node bench/append-bench.js`


------
https://chatgpt.com/codex/tasks/task_e_689c933faa2c8323b4c3d053d89244ec