### PR TITLE
feat: add streamable HTTP transport

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export interface Config {
   keyRequestIntervalMs: number;
   keyRequestMaxIntervalMs: number;
   keyBackupRecoveryKey?: string;
+  mcpPort: number;
 }
 
 export function loadConfig(): Config {
@@ -59,6 +60,7 @@ export function loadConfig(): Config {
     KEY_REQUEST_INTERVAL_MS: z.coerce.number().default(1000),
     KEY_REQUEST_MAX_INTERVAL_MS: z.coerce.number().default(300000),
     KEY_BACKUP_RECOVERY_KEY: z.string().optional(),
+    MCP_PORT: z.coerce.number().default(3000),
   });
   const result = schema.safeParse(process.env);
   if (!result.success) {
@@ -92,5 +94,6 @@ export function loadConfig(): Config {
     keyRequestIntervalMs: env.KEY_REQUEST_INTERVAL_MS,
     keyRequestMaxIntervalMs: env.KEY_REQUEST_MAX_INTERVAL_MS,
     keyBackupRecoveryKey: env.KEY_BACKUP_RECOVERY_KEY,
+    mcpPort: env.MCP_PORT,
   };
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,4 +1,6 @@
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import http from 'http';
+import { randomUUID } from 'node:crypto';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { buildMcpServer } from '../mcp-tools.js';
 import type { MatrixClient } from 'matrix-js-sdk';
 
@@ -8,7 +10,21 @@ export async function initMcpServer(
   enableSend: boolean,
   apiKey: string,
   logSecret: string | undefined,
+  port = 3000,
 ) {
   const srv = buildMcpServer(client, logDb, enableSend, apiKey, logSecret);
-  await srv.connect(new StdioServerTransport());
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+  });
+  await srv.connect(transport);
+  const httpServer = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/.well-known/mcp.json') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ transport: 'streamable-http' }));
+    } else {
+      void transport.handleRequest(req, res);
+    }
+  });
+  await new Promise((resolve) => httpServer.listen(port, resolve));
+  return { mcpServer: srv, httpServer };
 }

--- a/test/streamable-http.test.js
+++ b/test/streamable-http.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { buildMcpServer } from '../mcp-tools.js';
+
+const API_KEY = 'sekret';
+
+test('Streamable HTTP transport initialization', async () => {
+  const client = { getRooms: () => [] };
+  const srv = buildMcpServer(client, null, false, API_KEY, undefined);
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => 'sess',
+    enableJsonResponse: true,
+  });
+  await srv.connect(transport);
+  const server = http.createServer((req, res) => {
+    transport.handleRequest(req, res);
+  });
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port = server.address().port;
+  const resp = await fetch(`http://localhost:${port}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        clientInfo: { name: 'test', version: '1.0.0' },
+        capabilities: {},
+      },
+    }),
+  });
+  const data = await resp.json();
+  assert.equal(data.result.serverInfo.name, 'Beeper');
+  assert.ok(data.result.capabilities.tools.listChanged);
+  await srv.close();
+  await new Promise((resolve) => server.close(resolve));
+});


### PR DESCRIPTION
## Summary
- serve MCP over Streamable HTTP with discovery endpoint
- allow configuring MCP_PORT and wire HTTP server startup/shutdown
- cover Streamable HTTP initialization with an integration test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cae0233448323acbe0da355c980fc