### PR TITLE
Add multi-tenant scaffolding for MCP server

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Auto-approve
         uses: hmarr/auto-approve-action@v4
         with:
-          review-message: "Auto-approving trusted author PR"
+          review-message: 'Auto-approving trusted author PR'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
           sha: ${{ github.event.pull_request.head.sha }}
           context: tests
           state: success
-          description: "Compatibility status to unblock merges"
+          description: 'Compatibility status to unblock merges'

--- a/migrations/004_multitenancy.sql
+++ b/migrations/004_multitenancy.sql
@@ -1,0 +1,11 @@
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS owner_id text NOT NULL DEFAULT 'local';
+ALTER TABLE auto_send_rules ADD COLUMN IF NOT EXISTS owner_id text NOT NULL DEFAULT 'local';
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS owner_id text NOT NULL DEFAULT 'local';
+
+ALTER TABLE messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE auto_send_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY owner_isolation_messages ON messages USING (owner_id = current_setting('app.user', true));
+CREATE POLICY owner_isolation_rules ON auto_send_rules USING (owner_id = current_setting('app.user', true));
+CREATE POLICY owner_isolation_audit ON audit_log USING (owner_id = current_setting('app.user', true));

--- a/src/ingest/matrix.ts
+++ b/src/ingest/matrix.ts
@@ -1,5 +1,4 @@
 import { config } from '../config.js';
- 
 
 export async function startMatrixIngestLoop(): Promise<void> {
   // Minimal skeleton; implement full sync later

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -43,7 +43,11 @@ export async function initMcpServer(
       if (!uri || typeof uri !== 'string') throw new Error('Missing uri');
       const [base, qs = ''] = uri.split('?');
       const query = new URLSearchParams(qs);
-      const data = await handleResource(base, query);
+      const data = await handleResource(
+        base,
+        query,
+        extra?._meta?.apiKey ?? 'local',
+      );
       return { contents: [{ type: 'json', json: data }] };
     },
   );

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -4,6 +4,7 @@ import { queryLogs } from '../../utils.js';
 export type ResourceHandler = (
   pathParams: Record<string, string>,
   query: URLSearchParams,
+  owner: string,
 ) => Promise<any>;
 
 const routes: {
@@ -112,8 +113,8 @@ export function registerResources(logDb?: any, logSecret?: string) {
     return row ?? { eventId: params.eventId, kind: params['kind'] };
   });
 
-  addResource('im://matrix/index/status', async () => {
-    return indexStatus();
+  addResource('im://matrix/index/status', async (_params, _query, owner) => {
+    return indexStatus(owner);
   });
 }
 
@@ -121,13 +122,17 @@ export function listResources(): string[] {
   return routes.map((r) => r.template);
 }
 
-export async function handleResource(uri: string, query: URLSearchParams) {
+export async function handleResource(
+  uri: string,
+  query: URLSearchParams,
+  owner: string,
+) {
   for (const r of routes) {
     const m = uri.match(r.pattern);
     if (m) {
       const params: Record<string, string> = {};
       r.keys.forEach((k, i) => (params[k] = decodeURIComponent(m[i + 1])));
-      return r.handler(params, query);
+      return r.handler(params, query, owner);
     }
   }
   throw new Error(`Resource not found: ${uri}`);

--- a/src/mcp/tools/activity.ts
+++ b/src/mcp/tools/activity.ts
@@ -21,8 +21,10 @@ function getPool() {
 export const id = 'stats_activity';
 export const inputSchema = toolsSchemas.stats_activity as JSONSchema7;
 
-export async function handler(input: any) {
+export async function handler(input: any, owner = 'local') {
   const p = getPool();
+  const client = await (p as any).connect();
+  await client.query('SET app.user = $1', [owner]);
   const where: string[] = [];
   const args: any[] = [];
   let i = 1;
@@ -71,7 +73,8 @@ export async function handler(input: any) {
     GROUP BY bucket_key
     ORDER BY MIN(ts_utc)
   `;
-  const res = await p.query(sql, [...args, config.matrix.userId]);
+  const res = await client.query(sql, [...args, config.matrix.userId]);
+  client.release();
   return {
     filters: { ...input },
     bucket_def: {

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -5,7 +5,7 @@ import { toolsSchemas } from '../schemas/tools.js';
 export const id = 'search_messages';
 export const inputSchema = toolsSchemas.search_messages as JSONSchema7;
 
-export async function handler(input: any) {
+export async function handler(input: any, owner = 'local') {
   const hits = await searchHybrid(
     input.query,
     {
@@ -17,6 +17,7 @@ export async function handler(input: any) {
       types: input.types,
     },
     input.limit ?? 50,
+    owner,
   );
   return { hits };
 }

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -19,6 +19,7 @@ test('resources: history returns logs from SQLite', async () => {
   const res = await handleResource(
     'im://matrix/room/!r/history',
     new URLSearchParams('limit=10'),
+    'local',
   );
   assert.deepEqual(res.items, ['[a]', '[b]']);
 });
@@ -41,6 +42,7 @@ test('resources: media returns metadata by eventId', async () => {
   const res = await handleResource(
     'im://matrix/media/e1/file',
     new URLSearchParams(),
+    'local',
   );
   assert.equal(res.file, 'f.bin');
 });


### PR DESCRIPTION
## Summary
- add owner-based row-level security via new migration
- scope MCP HTTP requests to tenants and pass tenant ID to resources and tools
- propagate tenant ID to Postgres queries to enforce isolation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fcea7f29c8323baa62888456d5bbd