### PR TITLE
feat: add multi-tenant docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,23 @@ RUN npm run build
 FROM node:20-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
+
+# create unprivileged user for tenant isolation
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN addgroup -g $GROUP_ID app && \
+    adduser -u $USER_ID -G app -s /bin/sh -D appuser
+
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/mcp-tools.js ./
 COPY --from=build /app/utils.js ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && \
+    mkdir -p mx-cache room-logs && \
+    chown -R appuser:app ./
+
+VOLUME ["/app/mx-cache", "/app/room-logs"]
+USER appuser
+
 EXPOSE 3000 8757
 CMD ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ BeeperMCP is a small Matrix client wrapper that exposes chats and actions throug
 
    The script attempts to detect your Matrix homeserver, user ID and access token from Beeper/Element configuration. Prompts are validated to ensure a proper homeserver URL, user ID, and either an access token or password before saving to `.beeper-mcp-server.env`. It also offers to encrypt the session cache and room logs, configure log rotation size, and optionally enable the `send_message` tool.
 
+## Docker deployment
+
+The repository includes a multi-stage Dockerfile suitable for local or multi-tenant hosting. The runtime image runs as an unprivileged user and stores state under `/app/mx-cache` and `/app/room-logs`.
+
+Build the image (override `USER_ID`/`GROUP_ID` to match the host or tenant IDs):
+
+```bash
+docker build -t beeper-mcp .
+# docker build -t beeper-mcp --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) .
+```
+
+Run the container with isolated volumes and your environment file:
+
+```bash
+docker run -p 8757:8757 -p 3000:3000 \
+  -v mcp-cache:/app/mx-cache -v mcp-logs:/app/room-logs \
+  --env-file .beeper-mcp-server.env beeper-mcp
+```
+
+For multi-tenant deployments, start a separate container per user with distinct volumes and environment files.
+
 ## Usage
 
 Create a `.beeper-mcp-server.env` file containing at least `MCP_API_KEY`, `MATRIX_USERID`, and `MATRIX_TOKEN` (or `MATRIX_PASSWORD`). You can copy `.beeper-mcp-server.env.example` and edit it, or let the `setup.js` script generate one. If you provide only a password, the generated access token is saved to `mx-cache/session.json` and used automatically on future runs. The server is written in TypeScript so you'll need `ts-node` (installed by `setup.js`) to run it:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,15 +12,26 @@ services:
       - pgdata:/var/lib/postgresql/data
 
   app:
-    build: .
+    build:
+      context: .
+      args:
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
     environment:
       DATABASE_URL: postgres://postgres:postgres@db:5432/mcp
       MCP_BASE_URL: http://0.0.0.0:8757
     ports:
       - '8757:8757'
       - '3000:3000'
+    volumes:
+      - mx-cache:/app/mx-cache
+      - room-logs:/app/room-logs
+    env_file:
+      - .beeper-mcp-server.env
     depends_on:
       - db
 
 volumes:
   pgdata: {}
+  mx-cache: {}
+  room-logs: {}


### PR DESCRIPTION
## Summary
- run container as configurable non-root user with mounted cache and log volumes
- document container usage and multi-tenant isolation
- pass UID/GID build args and volumes in docker-compose

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fdad372848323a6469161b95d4dc8