### PR TITLE
Add Node 20 CI workflow with coverage and lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Test with coverage
-        run: |
-          NODE_V8_COVERAGE=coverage npm test
-          npx c8 report --reporter=text --reporter=lcov --temp-directory=coverage --report-dir=coverage
+        run: npx c8 --reporter=text --reporter=lcov --check-coverage --lines 80 --branches 80 --functions 80 --report-dir=coverage npm test
       - run: npm run lint
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- run CI on Node 20 with dependency caching
- build, test with c8 coverage, and lint in GitHub Actions

## Testing
- `npm ci`
- `npm run build`
- `npx c8 --reporter=text --reporter=lcov --check-coverage --lines 80 --branches 80 --functions 80 --report-dir=coverage npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0a834c6b0832398229a04a74457ce