### PR TITLE
build: export docker image on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Test with coverage
         run: npx c8 --reporter=text --reporter=lcov --check-coverage --lines 80 --branches 80 --functions 80 --report-dir=coverage npm test
       - run: npm run lint
+      - name: Determine version
+        run: echo "VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+      - run: npm run build:docker
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-image-${{ env.VERSION }}
+          path: docker-images/*.tar
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ room-logs
 mx-cache
 .aider*
 .test-resources*.db
+docker-images/*
+!docker-images/.gitkeep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ How We Work (Agent Guide)
 - Build and test flow:
   - Use `npm ci && npm run build` before running tests.
   - Run all tests via `npm test` or `npm run test:coverage` (compiles TS to `dist/` and runs Node test runner).
+- Versioning:
+  - Bump at least the minor `package.json` version for any behavioral change; major versions for breaking changes.
+  - Update the `releaseDate` field (YYYY-MM-DD) whenever the version changes.
 - MCP surface:
   - Prefer the Streamable HTTP MCP server initialized in `src/mcp.ts`. Avoid duplicating tool/resource wiring elsewhere.
   - Resources are registered via `registerResources(logDb, logSecret)` and backed by SQLite (`utils.js`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "beeper-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
+  "releaseDate": "2025-08-16",
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json && cp mcp-tools.js utils.js dist/",
@@ -9,6 +10,7 @@
     "start": "node dist/beeper-mcp-server.js",
     "test": "npm run build && node --test dist/tests/**/*.js",
     "test:coverage": "npm run build && c8 --check-coverage --lines 80 --branches 80 --functions 80 --exclude setup.js node --test dist/tests/**/*.js",
+    "build:docker": "bash scripts/build_docker.sh",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# build_docker.sh v1.1.0 (2025-08-16)
+set -euo pipefail
+
+VERSION=$(jq -r '.version' package.json)
+DATE=$(jq -r '.releaseDate' package.json)
+IMAGE_NAME="beeper-mcp:${VERSION}"
+OUTPUT_DIR="docker-images"
+
+mkdir -p "$OUTPUT_DIR"
+
+docker build -t "$IMAGE_NAME" .
+docker save "$IMAGE_NAME" -o "$OUTPUT_DIR/beeper-mcp-${VERSION}-${DATE}.tar"
+
+echo "Docker image saved to $OUTPUT_DIR/beeper-mcp-${VERSION}-${DATE}.tar"


### PR DESCRIPTION
## Summary
- version docker build artifacts with package version and release date
- upload versioned docker image artifact in CI
- document versioning policy for future commits

## Testing
- `npm ci`
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1115336748323b29d8a2f4007955e