### PR TITLE
feat: return activity share as percentage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beeper-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beeper-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@matrix-org/matrix-sdk-crypto-nodejs": "0.4.0-beta.1",
         "@matrix-org/olm": "^3.2.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beeper-mcp",
-  "version": "0.3.0",
-  "releaseDate": "2025-08-30",
+  "version": "0.4.0",
+  "releaseDate": "2025-08-16",
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json && cp mcp-tools.js utils.js dist/",

--- a/src/mcp/tools/activity.ts
+++ b/src/mcp/tools/activity.ts
@@ -63,7 +63,7 @@ export async function handler(input: any, owner = 'local') {
            COUNT(DISTINCT sender) AS unique_senders,
            COALESCE(SUM(words),0) AS words,
            COALESCE(SUM(attachments),0) AS attachments,
-           AVG(CASE WHEN sender = $${i++} THEN 1 ELSE 0 END)::float AS my_share_pct,
+           AVG(CASE WHEN sender = $${i++} THEN 1 ELSE 0 END)::float * 100 AS my_share_pct,
            AVG(NULLIF(words,0)) AS avg_len,
            STDDEV_POP(NULLIF(words,0)) AS stdev_len,
            MIN(ts_utc) AS start_utc,

--- a/tests/mcp/activity.spec.ts
+++ b/tests/mcp/activity.spec.ts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handler, __setTestPool } from '../../src/mcp/tools/activity.js';
+import { config } from '../../src/config.js';
+
+test('my_share_pct is returned as percentage', async () => {
+  const messages = [
+    {
+      sender: 'alice',
+      words: 10,
+      attachments: 0,
+      ts: new Date('2024-01-01T00:00:00Z'),
+    },
+    {
+      sender: 'bob',
+      words: 5,
+      attachments: 0,
+      ts: new Date('2024-01-01T01:00:00Z'),
+    },
+  ];
+  const pool = {
+    connect: async () => ({
+      query: async (sql: string) => {
+        if (typeof sql === 'string' && sql.startsWith('SET app.user')) {
+          return { rows: [] };
+        }
+        const myMessages = messages.filter(
+          (m) => m.sender === config.matrix.userId,
+        );
+        const words = messages.reduce((a, b) => a + b.words, 0);
+        const attachments = messages.reduce((a, b) => a + b.attachments, 0);
+        const avgWords = words / messages.length;
+        const variance =
+          messages.reduce((a, b) => a + Math.pow(b.words - avgWords, 2), 0) /
+          messages.length;
+        const stdev = Math.sqrt(variance);
+        return {
+          rows: [
+            {
+              bucket_key: '2024-01-01',
+              messages: messages.length,
+              unique_senders: new Set(messages.map((m) => m.sender)).size,
+              words,
+              attachments,
+              my_share_pct: (myMessages.length / messages.length) * 100,
+              avg_len: avgWords,
+              stdev_len: stdev,
+              start_utc: messages[0].ts.toISOString(),
+              end_utc: messages[messages.length - 1].ts.toISOString(),
+            },
+          ],
+        };
+      },
+      release: () => {},
+    }),
+    end: async () => {},
+  };
+
+  __setTestPool(pool as any);
+  const originalUser = config.matrix.userId;
+  config.matrix.userId = 'alice';
+  const res = await handler({});
+  config.matrix.userId = originalUser;
+  await pool.end();
+  __setTestPool(null as any);
+
+  assert.equal(res.buckets[0].my_share_pct, 50);
+});

--- a/tests/mcp/tools.spec.ts
+++ b/tests/mcp/tools.spec.ts
@@ -11,7 +11,7 @@ import {
   handler as recapHandler,
 } from '../../src/mcp/tools/recap.js';
 
-const ajv = new Ajv({ allErrors: true });
+const ajv = new (Ajv as any)({ allErrors: true });
 
 function hasCitation(obj: any) {
   return (


### PR DESCRIPTION
## Summary
- scale activity share to 0-100% in stats_activity
- cover stats_activity percentage with a unit test
- bump package version and release date

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a117fd44ec8323a7bbcd84909d13f4