### PR TITLE
Scope context queries by anchor timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beeper-mcp",
-  "version": "0.3.0",
-  "releaseDate": "2025-08-30",
+  "version": "0.4.0",
+  "releaseDate": "2025-08-16",
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json && cp mcp-tools.js utils.js dist/",


### PR DESCRIPTION
## Summary
- compute timestamp bounds around an anchor event and pass them to `queryLogs` so context queries can fetch older log windows
- test context retrieval for events outside the latest log slice
- bump package version to 0.4.0

## Testing
- `node --test test/resources.test.js`
- `npm test` *(fails: TypeScript compilation error in tests/mcp/tools.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a118f1fb388323a834e5d127d8bef8