### PR TITLE
feat: add sentiment trend smoothing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beeper-mcp",
-  "version": "0.4.0",
-  "releaseDate": "2025-08-16",
+  "version": "0.5.0",
+  "releaseDate": "2025-08-17",
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json && cp mcp-tools.js utils.js dist/",

--- a/src/mcp/schemas/tools.ts
+++ b/src/mcp/schemas/tools.ts
@@ -135,6 +135,8 @@ const sentiment_trends: JSONSchema7 = {
       type: 'array',
       items: { enum: ['text', 'audio', 'image', 'video'] },
     },
+    alpha: { type: 'number', minimum: 0, maximum: 1, default: 0.3 },
+    sensitivity: { type: 'number', minimum: 0, default: 0.5 },
   },
   required: ['target'],
 };

--- a/tests/mcp/sentimentTrends.spec.ts
+++ b/tests/mcp/sentimentTrends.spec.ts
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handler, __setTestPool } from '../../src/mcp/tools/sentimentTrends.js';
+
+test('computes EMA and change-point flag', async () => {
+  const rows = [
+    {
+      bucket_key: 'b1',
+      count: 1,
+      mean: 0.1,
+      median: 0.1,
+      stdev: 0,
+      p10: 0.1,
+      p90: 0.1,
+      pos_rate: 0,
+      neg_rate: 0,
+      subjectivity_mean: 0.5,
+    },
+    {
+      bucket_key: 'b2',
+      count: 1,
+      mean: 0.12,
+      median: 0.12,
+      stdev: 0,
+      p10: 0.12,
+      p90: 0.12,
+      pos_rate: 0,
+      neg_rate: 0,
+      subjectivity_mean: 0.5,
+    },
+    {
+      bucket_key: 'b3',
+      count: 1,
+      mean: 0.15,
+      median: 0.15,
+      stdev: 0,
+      p10: 0.15,
+      p90: 0.15,
+      pos_rate: 0,
+      neg_rate: 0,
+      subjectivity_mean: 0.5,
+    },
+    {
+      bucket_key: 'b4',
+      count: 1,
+      mean: 0.6,
+      median: 0.6,
+      stdev: 0,
+      p10: 0.6,
+      p90: 0.6,
+      pos_rate: 1,
+      neg_rate: 0,
+      subjectivity_mean: 0.5,
+    },
+  ];
+  const pool = {
+    connect: async () => ({
+      query: async (sql: string) => {
+        if (typeof sql === 'string' && sql.startsWith('SET app.user')) {
+          return { rows: [] };
+        }
+        return { rows };
+      },
+      release: () => {},
+    }),
+    end: async () => {},
+  };
+  __setTestPool(pool as any);
+  const res = await handler({
+    target: { all: true },
+    alpha: 0.5,
+    sensitivity: 0.2,
+  });
+  __setTestPool(null as any);
+
+  const expected = [0.1, 0.11, 0.13, 0.365];
+  res.buckets.forEach((b: any, i: number) => {
+    assert.ok(Math.abs(b.ema - expected[i]) < 1e-6);
+  });
+  assert.equal(res.buckets[3].change_point, true);
+  assert.ok(res.buckets.slice(0, 3).every((b: any) => !b.change_point));
+});


### PR DESCRIPTION
## Summary
- add exponential moving average smoothing and change-point detection to sentiment trends tool
- expose configurable alpha and sensitivity options
- cover sentiment trend analysis with unit tests and bump version to 0.5.0

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a11b3e6fb48323b6085ad024b142bd