### PR TITLE
ci: auto-publish docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,32 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract version
+        run: echo "VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+      - name: Set image name
+        run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Current state (as of this repo snapshot)
   - package.json consolidated; test scripts build first; `pg` is a dependency for analytics tools.
   - tsconfig.json is a single NodeNext project emitting to `dist/`.
   - CI uses `npm ci`, builds, then runs tests and lint.
+  - `.github/workflows/docker-publish.yml` builds and pushes Docker images to GHCR on every push to `main`, tagging each image with the package version, commit SHA, and `latest`.
 - Resources (src/mcp/resources.ts)
   - registerResources(logDb, logSecret) wires history/context/media to SQLite logs/media.
   - src/mcp.ts passes logDb/logSecret to registerResources.


### PR DESCRIPTION
## Summary
- Automate Docker image publishing to GHCR on every push to `main`
- Document Docker publishing workflow in AGENTS guide

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d04c7a2f4832397ac06505d09f295