### PR TITLE
test: add analytics integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beeper-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beeper-mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@matrix-org/matrix-sdk-crypto-nodejs": "0.4.0-beta.1",
         "@matrix-org/olm": "^3.2.15",
@@ -32,6 +32,7 @@
         "eslint": "^9.33.0",
         "globals": "^16.3.0",
         "husky": "^9.0.0",
+        "pg-mem": "^3.0.5",
         "prettier": "^3.2.5",
         "typescript": "^5.9.2"
       }
@@ -1119,6 +1120,25 @@
         }
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1279,6 +1299,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1407,6 +1434,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1424,6 +1469,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -2114,6 +2166,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2243,6 +2302,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2370,6 +2442,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2467,6 +2546,13 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2555,12 +2641,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
@@ -2832,6 +2948,23 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2850,6 +2983,29 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -2893,6 +3049,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -2903,6 +3069,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/oidc-client-ts": {
@@ -3133,6 +3309,78 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-mem": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.5.tgz",
+      "integrity": "sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.1"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-mem/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
@@ -3171,6 +3419,17 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.1.tgz",
+      "integrity": "sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
       }
     },
     "node_modules/picomatch": {
@@ -3413,6 +3672,27 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3512,6 +3792,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/retry": {
@@ -3665,6 +3955,24 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -4348,6 +4656,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "eslint .",
     "format": "prettier --check .",
     "start": "node dist/beeper-mcp-server.js",
-    "test": "npm run build && node --test dist/tests/**/*.js",
-    "test:coverage": "npm run build && c8 --check-coverage --lines 80 --branches 80 --functions 80 --exclude setup.js node --test dist/tests/**/*.js",
+    "test": "npm run build && node --test dist/tests test/analytics.test.js",
+    "test:coverage": "npm run build && c8 --check-coverage --lines 80 --branches 80 --functions 80 --exclude setup.js node --test dist/tests test/analytics.test.js",
     "build:docker": "bash scripts/build_docker.sh",
     "prepare": "husky"
   },
@@ -26,6 +26,7 @@
     "eslint": "^9.33.0",
     "globals": "^16.3.0",
     "husky": "^9.0.0",
+    "pg-mem": "^3.0.5",
     "prettier": "^3.2.5",
     "typescript": "^5.9.2"
   },

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,0 +1,205 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { newDb } from 'pg-mem';
+import {
+  handler as whoSaid,
+  __setTestPool as setWhoPool,
+} from '../dist/src/mcp/tools/whoSaid.js';
+import {
+  handler as sentimentTrends,
+  __setTestPool as setTrendsPool,
+} from '../dist/src/mcp/tools/sentimentTrends.js';
+import {
+  handler as sentimentDistribution,
+  __setTestPool as setDistPool,
+} from '../dist/src/mcp/tools/sentimentDistribution.js';
+import {
+  handler as activity,
+  __setTestPool as setActivityPool,
+} from '../dist/src/mcp/tools/activity.js';
+import { config } from '../dist/src/config.js';
+
+function setupDb() {
+  const db = newDb();
+  const settings = {};
+  db.public.registerFunction({
+    name: 'current_setting',
+    args: ['text', 'bool'],
+    returns: 'text',
+    impure: true,
+    implementation: (name) => settings[name] ?? null,
+  });
+  db.public.registerFunction({
+    name: 'nullif',
+    args: ['float', 'float'],
+    returns: 'float',
+    implementation: (a, b) => (a === b ? null : a),
+  });
+  db.public.registerFunction({
+    name: 'width_bucket',
+    args: ['float', 'float', 'float', 'text'],
+    returns: 'int',
+    implementation: (v, low, high, binsText) => {
+      const bins = Number(binsText);
+      const w = (high - low) / bins;
+      if (v < low) return 0;
+      if (v >= high) return bins + 1;
+      return Math.floor((v - low) / w) + 1;
+    },
+  });
+  const pg = db.adapters.createPg();
+  const rawPool = new pg.Pool();
+  const init = async () => {
+    const client = await rawPool.connect();
+    await client.query(`
+      CREATE TABLE messages_data (
+        event_id text PRIMARY KEY,
+        room_id text,
+        sender text,
+        text text,
+        ts_utc timestamptz,
+        lang text,
+        media_types text[],
+        sentiment_score real,
+        subjectivity real,
+        words real,
+        attachments int,
+        tz_day text,
+        tz_week int,
+        tz_month int,
+        tz_year int,
+        owner_id text
+      );
+    `);
+    await client.query(`
+      CREATE VIEW messages AS
+      SELECT * FROM messages_data
+      WHERE owner_id = current_setting('app.user', true);
+    `);
+    await client.query(
+      `INSERT INTO messages_data
+       (event_id, room_id, sender, text, ts_utc, lang, media_types, sentiment_score, subjectivity, words, attachments, tz_day, tz_week, tz_month, tz_year, owner_id)
+       VALUES
+       ('e1','r1','alice','hello','2024-01-01T00:00:00Z','en',ARRAY[]::text[],0.5,0.6,5,0,'2024-01-01',1,1,2024,'local'),
+       ('e2','r1','bob','hola','2024-01-02T00:00:00Z','es',ARRAY['image'], -0.4,0.4,3,1,'2024-01-02',1,1,2024,'local'),
+       ('e3','r2','alice','bye','2024-01-03T00:00:00Z','en',ARRAY[]::text[],0.1,0.5,1,0,'2024-01-03',1,1,2024,'local'),
+       ('e4','r1','alice','ciao','2024-01-01T00:00:00Z','it',ARRAY[]::text[],0.2,0.7,2,0,'2024-01-01',1,1,2024,'other')
+      `,
+    );
+    client.release();
+  };
+  const pool = {
+    connect: async () => {
+      const client = await rawPool.connect();
+      return {
+        query: async (sql, params) => {
+          if (typeof sql === 'string' && sql.startsWith('SET app.user')) {
+            settings['app.user'] = params[0];
+            return { rows: [] };
+          }
+          if (typeof sql === 'string' && sql.includes('STDDEV_POP')) {
+            sql = sql
+              .replace(/STDDEV_POP\(NULLIF\(words,0\)\)/gi, '0')
+              .replace(/STDDEV_POP\(sentiment_score\)/gi, '0');
+          }
+          if (typeof sql === 'string' && sql.includes('PERCENTILE_CONT')) {
+            sql = sql
+              .replace(
+                /PERCENTILE_CONT\(0\.5\) WITHIN GROUP \(ORDER BY sentiment_score\)/gi,
+                'AVG(sentiment_score)',
+              )
+              .replace(
+                /PERCENTILE_CONT\(0\.1\) WITHIN GROUP \(ORDER BY sentiment_score\)/gi,
+                'MIN(sentiment_score)',
+              )
+              .replace(
+                /PERCENTILE_CONT\(0\.9\) WITHIN GROUP \(ORDER BY sentiment_score\)/gi,
+                'MAX(sentiment_score)',
+              );
+          }
+          return client.query(sql, params);
+        },
+        release: () => client.release(),
+      };
+    },
+    end: async () => rawPool.end(),
+  };
+  return { pool, init };
+}
+
+test('analytics tools filters, buckets, and RLS', async (t) => {
+  const { pool, init } = setupDb();
+  await init();
+  setWhoPool(pool);
+  setTrendsPool(pool);
+  setDistPool(pool);
+  setActivityPool(pool);
+  const origUser = config.matrix.userId;
+  config.matrix.userId = 'alice';
+
+  await t.test('who_said filters participants/lang/types', async () => {
+    const res = await whoSaid({
+      pattern: 'hola',
+      participants: ['bob'],
+      lang: 'es',
+      types: ['image'],
+    });
+    assert.equal(res.hits.length, 1);
+    assert.equal(res.hits[0].sender, 'bob');
+    const none = await whoSaid({ pattern: 'ciao' });
+    assert.equal(none.hits.length, 0);
+    const other = await whoSaid({ pattern: 'ciao' }, 'other');
+    assert.equal(other.hits.length, 1);
+  });
+
+  await t.test('sentiment_distribution bins and filters', async () => {
+    const res = await sentimentDistribution({
+      bins: 4,
+      participants: ['bob'],
+      lang: 'es',
+      types: ['image'],
+    });
+    assert.deepEqual(res.counts, [0, 1, 0, 0, 0]);
+    assert.equal(res.summary.count, 1);
+    assert.ok(Math.abs(res.summary.mean + 0.4) < 1e-6);
+    const rls = await sentimentDistribution({ bins: 4 }, 'other');
+    assert.deepEqual(rls.counts, [0, 0, 1, 0, 0]);
+    assert.equal(rls.summary.count, 1);
+  });
+
+  await t.test('sentiment_trends bucket stats and RLS', async () => {
+    const res = await sentimentTrends({
+      bucket: 'day',
+      participants: ['bob'],
+      lang: 'es',
+      types: ['image'],
+    });
+    assert.equal(res.buckets.length, 1);
+    assert.equal(res.buckets[0].subjectivity_mean, 0.4);
+    const rls = await sentimentTrends({ bucket: 'day' }, 'other');
+    assert.equal(rls.buckets.length, 1);
+    assert.equal(rls.buckets[0].mean, 0.2);
+  });
+
+  await t.test('stats_activity filters and RLS', async () => {
+    const res = await activity({
+      bucket: 'year',
+      target: { participant: 'bob' },
+      lang: 'es',
+      types: ['image'],
+    });
+    assert.equal(res.buckets[0].messages, 1);
+    assert.equal(res.buckets[0].my_share_pct, 0);
+    const allLocal = await activity({ bucket: 'year' });
+    assert.equal(allLocal.buckets[0].messages, 3);
+    const allOther = await activity({ bucket: 'year' }, 'other');
+    assert.equal(allOther.buckets[0].messages, 1);
+  });
+
+  config.matrix.userId = origUser;
+  await pool.end();
+  setWhoPool(null);
+  setTrendsPool(null);
+  setDistPool(null);
+  setActivityPool(null);
+});


### PR DESCRIPTION
## Summary
- add pg-mem backed integration tests for analytics tools
- verify participants/lang/type filters, histogram binning, and RLS enforcement
- wire npm test to run new analytics integration suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a11cb7210c8323a17b72de48fa0577