### PR TITLE
chore: publish Docker images to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Publish Docker image
 on:
   push:
     branches: [main]
+    tags: ['v*']
 
 jobs:
   docker:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ docker build -t beeper-mcp .
 # docker build -t beeper-mcp --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) .
 ```
 
+Pre-built images are published to GitHub Container Registry on each push to
+`main` and for version tags. Replace `<owner>` with the repository owner and
+pull the image directly:
+
+```bash
+docker pull ghcr.io/<owner>/beepermcp:latest
+# or a specific version
+docker pull ghcr.io/<owner>/beepermcp:v1.2.3
+```
+
 Run the container with isolated volumes and your environment file:
 
 ```bash


### PR DESCRIPTION
## Summary
- publish Docker images to GitHub Container Registry on main and version tags
- document how to pull pre-built images from GHCR

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c5eb2c648323b5e05a272608fcab