### PR TITLE
Allow manual Docker publish workflow runs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN apk add --no-cache python3 make g++ \
+    && npm ci
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- allow manual `workflow_dispatch` triggers for the Docker publish workflow
- install build dependencies in Dockerfile so Docker publish workflow can build successfully on GitHub Actions

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cbb15044832396d2b898c1e3cf1a