### PR TITLE
Allow manual Docker publish workflow runs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  workflow_dispatch:
 
 jobs:
   docker:
@@ -13,10 +14,13 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Extract version
         run: echo "VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
       - name: Set image name
-        run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+        run: echo "IMAGE_NAME=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN apk add --no-cache python3 make g++ \
+    && npm ci
 COPY . .
 RUN npm run build
 

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# build_docker.sh v1.1.0 (2025-08-16)
+# build_docker.sh v1.1.1 (2025-08-16)
 set -euo pipefail
 
-VERSION=$(jq -r '.version' package.json)
-DATE=$(jq -r '.releaseDate' package.json)
+VERSION=$(node -p "require('./package.json').version")
+DATE=$(node -p "require('./package.json').releaseDate")
 IMAGE_NAME="beeper-mcp:${VERSION}"
 OUTPUT_DIR="docker-images"
 


### PR DESCRIPTION
## Summary
- allow manual `workflow_dispatch` triggers for the Docker publish workflow
- install build dependencies in Dockerfile so Docker publish workflow can build successfully on GitHub Actions
- compute lowercase image name without bash-only syntax
- set up Node and extract the package version with Node to avoid missing `jq` on GitHub runners
- rewrite build script to read version and release date via Node instead of `jq`

## Testing
- `npm ci`
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1cbb15044832396d2b898c1e3cf1a