### PR TITLE
fix: run beeper-mcp server in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ VOLUME ["/app/mx-cache", "/app/room-logs"]
 USER appuser
 
 EXPOSE 3000 8757
-CMD ["node", "dist/server.js"]
+CMD ["node", "dist/beeper-mcp-server.js"]


### PR DESCRIPTION
## Summary
- run compiled `beeper-mcp-server` in Docker CMD

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a227706eb883238b0b561402781c14