### PR TITLE
chore: add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+coverage/
+
+# Local development
+docker-images/
+room-logs/
+mx-cache/
+bench/
+test/
+tests/
+
+# Git & metadata
+.git/
+.gitignore
+.github/
+.husky/
+
+# Misc
+*.log
+npm-debug.log*
+.DS_Store
+.aider*
+.test-resources*.db
+.beeper-mcp-server.env


### PR DESCRIPTION
## Summary
- reduce Docker build context by ignoring dev and build outputs

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a231dd61d88323819a9068d106247a