### PR TITLE
Run Docker image help check in build script

### DIFF
--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# build_docker.sh v1.1.1 (2025-08-16)
+# build_docker.sh v1.1.2 (2025-08-17)
 set -euo pipefail
 
 VERSION=$(node -p "require('./package.json').version")
@@ -10,6 +10,7 @@ OUTPUT_DIR="docker-images"
 mkdir -p "$OUTPUT_DIR"
 
 docker build -t "$IMAGE_NAME" .
+docker run --rm "$IMAGE_NAME" node dist/beeper-mcp-server.js --help
 docker save "$IMAGE_NAME" -o "$OUTPUT_DIR/beeper-mcp-${VERSION}-${DATE}.tar"
 
 echo "Docker image saved to $OUTPUT_DIR/beeper-mcp-${VERSION}-${DATE}.tar"


### PR DESCRIPTION
## Summary
- Run the MCP server help command after building the Docker image to verify it starts

## Testing
- `npm ci`
- `npm run build`
- `npm test`
- `scripts/build_docker.sh` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a232d3a31883238176861eb7e97c7b