### PR TITLE
chore: refine docker ignore rules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,12 @@ tests/
 .gitignore
 .github/
 .husky/
+.vscode/
+.idea/
+
+# Environment
+*.env
+.beeper-mcp-server.env
 
 # Misc
 *.log
@@ -25,4 +31,3 @@ npm-debug.log*
 .DS_Store
 .aider*
 .test-resources*.db
-.beeper-mcp-server.env


### PR DESCRIPTION
## Summary
- expand `.dockerignore` to skip editor settings, env files, and other local artifacts

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a241fbbd088323a8ebe6955c034131