### PR TITLE
fix: correct version extraction in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 22
       - name: Extract version
-        run: echo "VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+        run: echo VERSION=$(node -p "require('./package.json').version") >> $GITHUB_ENV
       - name: Set image name
         run: echo "IMAGE_NAME=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- remove outer quotes around command substitution so node can write VERSION to `$GITHUB_ENV`

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a242b34d8c8323b0eea27b9b034598