### PR TITLE
fix: resolve version extraction quoting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
         run: npx c8 --reporter=text --reporter=lcov --check-coverage --lines 80 --branches 80 --functions 80 --report-dir=coverage npm test
       - run: npm run lint
       - name: Determine version
-        run: echo "VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+        run: |
+          echo "VERSION=$(node -p 'require("./package.json").version')" >> "$GITHUB_ENV"
       - run: npm run build:docker
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,9 +18,11 @@ jobs:
         with:
           node-version: 22
       - name: Extract version
-        run: echo VERSION=$(node -p "require('./package.json').version") >> $GITHUB_ENV
+        run: |
+          echo "VERSION=$(node -p 'require("./package.json").version')" >> "$GITHUB_ENV"
       - name: Set image name
-        run: echo "IMAGE_NAME=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+        run: |
+          echo "IMAGE_NAME=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- fix version extraction in Docker publishing workflow by using shell-safe quoting
- align CI workflow's version step with same quoting approach

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24593f1f083238a52d24cf97e9eea