### PR TITLE
ci: extract version in docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,8 +18,10 @@ jobs:
         with:
           node-version: 22
       - name: Extract version
+        shell: bash
         run: |
-          echo "VERSION=$(node -p 'require("./package.json").version')" >> "$GITHUB_ENV"
+          VERSION=$(jq -r .version package.json 2>/dev/null || npm pkg get version | tr -d '"')
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Set image name
         run: |
           echo "IMAGE_NAME=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- use a bash step to parse package.json version for docker publishing

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a248c1524c8323b294152f4012ec73