### PR TITLE
ci: fix version extraction in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,11 @@ jobs:
       - name: Test with coverage
         run: npx c8 --reporter=text --reporter=lcov --check-coverage --lines 80 --branches 80 --functions 80 --report-dir=coverage npm test
       - run: npm run lint
-      - name: Determine version
+      - name: Extract version
+        shell: bash
         run: |
-          echo "VERSION=$(node -p 'require("./package.json").version')" >> "$GITHUB_ENV"
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - run: npm run build:docker
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Extract version
         shell: bash
         run: |
-          VERSION=$(jq -r .version package.json 2>/dev/null || npm pkg get version | tr -d '"')
+          VERSION=$(node -p "require('./package.json').version")
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Set image name
         run: |


### PR DESCRIPTION
## Summary
- ensure Docker publish workflow extracts package version via node -p and exports to env
- align CI workflow with same version extraction logic

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24c3f29088323b7c617fd9f442896