### PR TITLE
chore(ci): read version via jq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,7 @@ jobs:
       - name: Test with coverage
         run: npx c8 --reporter=text --reporter=lcov --check-coverage --lines 80 --branches 80 --functions 80 --report-dir=coverage npm test
       - run: npm run lint
-      - name: Extract version
-        shell: bash
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+      - run: echo "VERSION=$(jq -r .version package.json)" >> "$GITHUB_ENV"
       - run: npm run build:docker
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,11 +17,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Extract version
-        shell: bash
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+      - run: echo "VERSION=$(jq -r .version package.json)" >> "$GITHUB_ENV"
       - name: Set image name
         run: |
           echo "IMAGE_NAME=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- derive package version for workflows using jq

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a252b184cc8323a5d256a1ee5a8f6a