### PR TITLE
ci: derive version from npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test with coverage
         run: npx c8 --reporter=text --reporter=lcov --check-coverage --lines 80 --branches 80 --functions 80 --report-dir=coverage npm test
       - run: npm run lint
-      - run: echo "VERSION=$(jq -r .version package.json)" >> "$GITHUB_ENV"
+      - run: echo "VERSION=$(npm pkg get version | tr -d '\"')" >> "$GITHUB_ENV"
       - run: npm run build:docker
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: echo "VERSION=$(jq -r .version package.json)" >> "$GITHUB_ENV"
+      - run: echo "VERSION=$(npm pkg get version | tr -d '\"')" >> "$GITHUB_ENV"
       - name: Set image name
         run: |
           echo "IMAGE_NAME=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- set VERSION env var using `npm pkg get version` in CI workflows

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25bdecf5c8323a8ae5694fa8909d8